### PR TITLE
Include <cmatch> in the misp4_lag example

### DIFF
--- a/examples/misp4_lag.cpp
+++ b/examples/misp4_lag.cpp
@@ -1,4 +1,5 @@
 #include "codd.hpp"
+#include <cmath>
 #include <vector>
 #include <set>
 #include <unordered_set>


### PR DESCRIPTION
When I tried to build CODD on Ubuntu 24.04 (WSL2 on Windows 11) with GCC 13.3.0, I encountered the following error:

```
/home/kuro/code/CODD/examples/misp4_lag.cpp:427:16: error: ‘floor’ is not a member of ‘std’
  427 |    return std::floor(dualBound + epsilon);
      |                ^~~~~
/home/kuro/code/CODD/examples/misp4_lag.cpp: In function ‘double LagBound(int, const std::vector<int>&, const GNSet&, const std::vector<double>&, const PairMap&)’:
/home/kuro/code/CODD/examples/misp4_lag.cpp:494:16: error: ‘floor’ is not a member of ‘std’
  494 |    return std::floor(lb + epsilon);
```

This seems to be because `<cmath>`, where `std::floor` is defined, is not included. Once I include `<cmath>`, everything is successfully compiled.